### PR TITLE
Enhancing actions and commands error handling

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -114,7 +114,7 @@ they are allowed to access and generate a kubeconfig for a chosen cluster.`,
 		// Gathering the OIDC server configuration
 		var res *actions.OIDCResponse
 		if res, err = actions.NewOIDCConfiguration(logger, client).Handle(viper.GetString(OIDCServer)); err != nil {
-			return err
+			return fmt.Errorf("cannot obtain the OIDC configuration (%w)", err)
 		}
 
 		pkce := actions.NewCodeVerifier(logger).Handle()
@@ -122,7 +122,7 @@ they are allowed to access and generate a kubeconfig for a chosen cluster.`,
 		var url string
 		url, err = actions.NewAuthenticationURI(logger, viper.GetString(OIDCClientID), pkce, res).Handle()
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot generate the authentatication URI (%w)", err)
 		}
 
 		fmt.Println("")
@@ -142,7 +142,7 @@ they are allowed to access and generate a kubeconfig for a chosen cluster.`,
 		var token, refresh string
 		token, refresh, err = actions.NewGetToken(logger, res.TokenEndpoint, viper.GetString(OIDCClientID), code, pkce, client).Handle()
 		if err != nil {
-			return fmt.Errorf("cannot proceed to login due to an error: %w", err)
+			return fmt.Errorf("cannot proceed to login due to an error (%w)", err)
 		}
 
 		viper.Set(TokenEndpoint, res.TokenEndpoint)
@@ -198,7 +198,7 @@ they are allowed to access and generate a kubeconfig for a chosen cluster.`,
 			},
 		}
 		if err != nil {
-			return fmt.Errorf("cannot read Kubernetes CA from file: %w", err)
+			return fmt.Errorf("cannot read Kubernetes CA from file (%w)", err)
 		}
 
 		scheme := runtime.NewScheme()
@@ -216,9 +216,7 @@ they are allowed to access and generate a kubeconfig for a chosen cluster.`,
 		path, _ := cmd.Flags().GetString("kubeconfig-path")
 
 		if err = afero.WriteFile(afero.NewOsFs(), path, a.Bytes(), os.ModePerm); err != nil {
-			msg := "cannot save generated kubeconfig"
-			logger.Error(msg, zap.Error(err))
-			return errors.New(msg)
+			return fmt.Errorf("cannot save generated kubeconfig (%w)", err)
 		}
 
 		fmt.Println("Your login procedure has been completed!")
@@ -235,7 +233,6 @@ they are allowed to access and generate a kubeconfig for a chosen cluster.`,
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }

--- a/internal/actions/create_auth_uri.go
+++ b/internal/actions/create_auth_uri.go
@@ -20,6 +20,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"fmt"
 	"net/url"
 	"regexp"
 
@@ -59,6 +60,7 @@ func (r AuthenticationURI) Handle() (authURI string, err error) {
 	u, err = url.Parse(r.authEndpoint)
 	if err != nil {
 		r.logger.Error("Cannot parse auth endpoint", zap.String("authEndpoint", r.authEndpoint), zap.Error(err))
+		err = fmt.Errorf("non well-formed endpoint")
 		return
 	}
 

--- a/internal/actions/get_token.go
+++ b/internal/actions/get_token.go
@@ -19,6 +19,7 @@ package actions
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -65,12 +66,14 @@ func (r GetToken) Handle() (idToken, refreshToken string, err error) {
 	tokenURL, err = url.Parse(r.tokenEndpoint)
 	if err != nil {
 		r.logger.Error("Cannot retrieve OIDC token due to non well-formed endpoint", zap.Error(err), zap.String("tokenEndpoint", r.tokenEndpoint))
+		err = fmt.Errorf("non well-formed endpoint")
 		return
 	}
 
 	var res *http.Response
 	if res, err = r.client.Post(tokenURL.String(), "application/x-www-form-urlencoded", strings.NewReader(d.Encode())); err != nil {
-		r.logger.Error("Cannot reach the server", zap.Error(err), zap.String("uri", tokenURL.String()))
+		r.logger.Error("The server returned an error", zap.Error(err), zap.String("uri", tokenURL.String()))
+		err = fmt.Errorf("the server returned an error")
 		return
 	}
 	defer func() { _ = res.Body.Close() }()
@@ -78,17 +81,20 @@ func (r GetToken) Handle() (idToken, refreshToken string, err error) {
 	var b []byte
 	if b, err = ioutil.ReadAll(res.Body); err != nil {
 		r.logger.Error("Cannot read response body", zap.Error(err))
+		err = fmt.Errorf("cannot read response body")
 		return
 	}
 	p := &tokenResponse{}
 	if err = json.Unmarshal(b, p); err != nil {
 		r.logger.Error("Cannot unmarshal JSON response", zap.Error(err))
+		err = fmt.Errorf("the response body is not a valid JSON")
 		return
 	}
 
 	if len(p.Error) > 0 {
 		err = errors.New(p.Error)
 		r.logger.Error("Token retrieval failed", zap.Error(err))
+		err = fmt.Errorf("server returned the error %s", p.Error)
 		return
 	}
 


### PR DESCRIPTION
Closes #9.

Output:

```
# kubectl-login --oidc-server=https://clastix.io --oidc-client-id=kubectl
Error: cannot obtain the OIDC configuration (the response body is not a valid JSON)
```

As usual, detailed logs can be extracted using the `-v||--verbose` CLI flag, as following.


```
# kubectl-login --oidc-server=https://clastix.io --oidc-client-id=kubectl -v
2021-01-30T14:41:35.331+0100	INFO	cmd/root.go:105	Starting the login procedure
2021-01-30T14:41:35.331+0100	INFO	actions/oidc_config.go:62	Getting OIDC configuration from the server	{"OIDCServer": "https://clastix.io"}
2021-01-30T14:41:35.451+0100	ERROR	actions/oidc_config.go:76	Cannot unmarshal OIDC configuration	{"OIDCServer": "https://clastix.io", "error": "invalid character '<' looking for beginning of value", "body": "REDACTED"}
github.com/clastix/kubectl-login/internal/actions.PKCELogin.Handle
	/home/prometherion/Documents/clastix/kubectl-login/internal/actions/oidc_config.go:76
github.com/clastix/kubectl-login/cmd.glob..func3
	/home/prometherion/Documents/clastix/kubectl-login/cmd/root.go:116
github.com/spf13/cobra.(*Command).execute
	/home/prometherion/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:850
github.com/spf13/cobra.(*Command).ExecuteC
	/home/prometherion/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:958
github.com/spf13/cobra.(*Command).Execute
	/home/prometherion/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:895
github.com/clastix/kubectl-login/cmd.Execute
	/home/prometherion/Documents/clastix/kubectl-login/cmd/root.go:235
main.main
	/home/prometherion/Documents/clastix/kubectl-login/main.go:21
runtime.main
	/usr/lib/golang/src/runtime/proc.go:203
Error: cannot obtain the OIDC configuration (the response body is not a valid JSON)
exit status 1

```