### PR TITLE
OIDC HTTP client configurable timeout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Flags:
       --k8s-server-ca-path string       Path to the Kubernetes API server certificate authority PEM encoded file
       --kubeconfig-path string          Path to the generated kubeconfig file upon resulting login procedure to access the Kubernetes cluster (default "oidc.kubeconfig")
       --oidc-client-id string           The OIDC client ID provided
+      --oidc-client-timeout duration    Define the timeout in duration for the HTTP requests to the OIDC server
       --oidc-insecure-skip-tls-verify   Disable TLS certificate verification for the OIDC server
       --oidc-server string              The OIDC server URL to connect to
       --oidc-server-ca-path string      Path to the OIDC server certificate authority PEM encoded file

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -25,6 +25,7 @@ const (
 	// OIDC viper keys
 	OIDCServer               = "oidc.server"
 	OIDCClientID             = "oidc.clientid"
+	OIDCTimeoutDuration      = "oidc.timeout"
 	OIDCSkipTLSVerify        = "oidc.ca.insecure"
 	OIDCCertificateAuthority = "oidc.ca.path"
 	// Token viper keys
@@ -38,6 +39,7 @@ var (
 		// OIDC flags
 		OIDCServer:               "oidc-server",
 		OIDCClientID:             "oidc-client-id",
+		OIDCTimeoutDuration:      "oidc-client-timeout",
 		OIDCSkipTLSVerify:        "oidc-insecure-skip-tls-verify",
 		OIDCCertificateAuthority: "oidc-server-ca-path",
 		// Kubernetes flags

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,6 +64,11 @@ they are allowed to access and generate a kubeconfig for a chosen cluster.`,
 		if v, _ := cmd.Flags().GetString(flagsMap[OIDCClientID]); len(v) > 0 {
 			viper.Set(OIDCClientID, v)
 		}
+
+		if cmd.Flag(flagsMap[OIDCTimeoutDuration]).Changed {
+			v, _ := cmd.Flags().GetDuration(flagsMap[OIDCTimeoutDuration])
+			viper.Set(OIDCTimeoutDuration, v)
+		}
 		if cmd.Flag(flagsMap[OIDCSkipTLSVerify]).Changed {
 			v, _ := cmd.Flags().GetBool(flagsMap[OIDCSkipTLSVerify])
 			viper.Set(OIDCSkipTLSVerify, v)
@@ -106,7 +111,7 @@ they are allowed to access and generate a kubeconfig for a chosen cluster.`,
 
 		// Creating OIDC server HTTP client with TLS handling
 		var client *oidc.HTTPClient
-		client, err = oidc.NewHTTPClient(viper.GetString(OIDCCertificateAuthority), viper.GetBool(OIDCSkipTLSVerify))
+		client, err = oidc.NewHTTPClient(viper.GetString(OIDCCertificateAuthority), viper.GetDuration(OIDCTimeoutDuration), viper.GetBool(OIDCSkipTLSVerify))
 		if err != nil {
 			return
 		}
@@ -246,6 +251,7 @@ func init() {
 	rootCmd.PersistentFlags().String(flagsMap[OIDCServer], viper.GetString(OIDCServer), "The OIDC server URL to connect to")
 	rootCmd.PersistentFlags().String(flagsMap[OIDCClientID], viper.GetString(OIDCClientID), "The OIDC client ID provided")
 	rootCmd.PersistentFlags().Bool(flagsMap[OIDCSkipTLSVerify], viper.GetBool(OIDCSkipTLSVerify), "Disable TLS certificate verification for the OIDC server")
+	rootCmd.PersistentFlags().Duration(flagsMap[OIDCTimeoutDuration], viper.GetDuration(OIDCTimeoutDuration), "Define the timeout in duration for the HTTP requests to the OIDC server")
 	rootCmd.PersistentFlags().String(flagsMap[OIDCCertificateAuthority], viper.GetString(OIDCCertificateAuthority), "Path to the OIDC server certificate authority PEM encoded file")
 
 	rootCmd.PersistentFlags().String(flagsMap[K8SAPIServer], viper.GetString(K8SAPIServer), "Endpoint of the Kubernetes API server to connect to")

--- a/internal/oidc/oidc_client.go
+++ b/internal/oidc/oidc_client.go
@@ -21,6 +21,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/spf13/afero"
 )
@@ -52,9 +53,10 @@ type HTTPClient struct {
 	http.Client
 }
 
-func NewHTTPClient(certificateAuthorityPath string, insecureSkipVerify bool) (client *HTTPClient, err error) {
+func NewHTTPClient(certificateAuthorityPath string, timeout time.Duration, insecureSkipVerify bool) (client *HTTPClient, err error) {
 	return &HTTPClient{
 		Client: http.Client{
+			Timeout: timeout,
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
 					//nolint:gosec


### PR DESCRIPTION
The option can be passed with CLI flag `oidc-client-timeout` and stored in the `oidc.timeout` configuration file as key using the Go duration format.