### PR TITLE
Using Kubernetes API address as cluster name in the resulting kubeconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,10 @@ apiVersion: v1
 clusters:
   - cluster:
       server: https://kube-apiserver:6443
-    name: kubernetes
+    name: http_kube-apiserver_6443
 contexts:
   - context:
-      cluster: kubernetes
+      cluster: http_kube-apiserver_6443
       user: oidc
     name: oidc
 current-context: oidc


### PR DESCRIPTION
Closes #18.

Sample output:

```yaml
apiVersion: v1
clusters:
- cluster:
    insecure-skip-tls-verify: true
    server: https://cmp.clastix.io:9443
  name: https_cmp.clastix.io_9443
contexts:
- context:
    cluster: https_cmp.clastix.io_9443
    user: oidc
  name: oidc
current-context: oidc
kind: Config
preferences: {}
users:
- name: oidc
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1beta1
      args:
      - login
      - get-token
      command: kubectl
      env: null
      provideClusterInfo: false
```

In the end, went for the pattern `SCHEME_HOSTNAME_PORT` to avoid collisions, mostly for the API port.